### PR TITLE
fixed cpp-tests ClickAndMoveTestCase bug

### DIFF
--- a/tests/cpp-tests/Classes/ClickAndMoveTest/ClickAndMoveTest.cpp
+++ b/tests/cpp-tests/Classes/ClickAndMoveTest/ClickAndMoveTest.cpp
@@ -48,19 +48,23 @@ void ClickAndMoveTestCase::onTouchEnded(Touch* touch, Event  *event)
     auto location = touch->getLocation();
 
     auto s = getChildByTag(kTagSprite);
-    s->stopAllActions();
-    s->runAction( MoveTo::create(1, Vec2(location.x, location.y) ) );
-    float o = location.x - s->getPosition().x;
-    float a = location.y - s->getPosition().y;
-    float at = (float) CC_RADIANS_TO_DEGREES( atanf( o/a) );
     
-    if( a < 0 ) 
-    {
-        if(  o < 0 )
-            at = 180 + fabs(at);
-        else
-            at = 180 - fabs(at);    
-    }
-    
-    s->runAction( RotateTo::create(1, at) );
+	if (s->getPosition().x != location.x || s->getPosition().y != location.y)
+	{
+		s->stopAllActions();
+		s->runAction(MoveTo::create(1, Vec2(location.x, location.y)));
+		float o = location.x - s->getPosition().x;
+		float a = location.y - s->getPosition().y;
+		float at = (0.f == a) ? 90.f : (float)CC_RADIANS_TO_DEGREES(atanf(o / a));
+
+		if (a <= 0)
+		{
+			if (o < 0)
+				at = 180 + fabs(at);
+			else
+				at = 180 - fabs(at);
+		}
+
+		s->runAction(RotateTo::create(1, at));
+	}
 }


### PR DESCRIPTION
The sprite (Grossini) need't move when touch position is the same as sprite's (Grossini) position.
And when "a" equal 0,  "atanf(o / a)" will have problem.
